### PR TITLE
Allowing for custom environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,16 @@ npm install --save-dev broccoli-env
 var env = require('broccoli-env').getEnv();
 console.log(env) // => 'development' or 'production'
 ```
+
+```js
+var env = require('broccoli-env').setEnvs(['development','production', 'testing']).getEnv();
+console.log(env) // => 'development', 'production' or 'testing'
+```
+
+## Logic
+
+- The default `envs` list is `['development', 'production']`
+- The default environment is the first of the `envs` list
+- If `BROCCOLI_ENV` is not defined, the default environment is assumed
+- If `BROCCOLI_ENV` value is not in the `envs` list, the default environment is assumed
+- Whenever the `envs` list is updated, the environment is resubmitted

--- a/index.js
+++ b/index.js
@@ -1,8 +1,54 @@
-exports.getEnv = getEnv
-function getEnv () {
-  var env = process.env.BROCCOLI_ENV || 'development'
-  if (env !== 'production' && env !== 'development') {
-    throw new Error('Environment set to "' + env + '", but only BROCCOLI_ENV=production and BROCCOLI_ENV=development are supported at the moment')
-  }
-  return env
+var defaultEnvs = ['development', 'production']
+
+function Env() {
+  return this.init()
 }
+
+Env.prototype = {
+
+  init: function() {
+    this.setEnvs(defaultEnvs)
+
+    if (process.env.BROCCOLI_ENV) {
+      this.setEnv(process.env.BROCCOLI_ENV)
+    }
+
+    return this
+  },
+
+  getEnv: function () {
+    return this.env
+  },
+
+  setEnv: function(env) {
+    if (this.envs.indexOf(env) === -1) {
+      this.env = this.envs[0]
+    }
+    else {
+      this.env = env
+    }
+
+    return this
+  },
+
+  getEnvs: function() {
+    return this.envs
+  },
+
+  setEnvs: function(envs) {
+    if (!Array.isArray(envs)) {
+      throw new Error('Parameter "envs" should be an array')
+    }
+
+    this.envs = envs
+
+    this.setEnv(this.env)
+
+    return this
+  }
+
+}
+
+module.exports = (function() {
+  return new Env()
+})()

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "broccoli-env",
-  "description": "Get the environment (production, development) from BROCCOLI_ENV",
+  "description": "Get the environment from BROCCOLI_ENV",
   "version": "0.0.1",
   "author": "Jo Liss <joliss42@gmail.com>",
   "main": "index.js",
@@ -13,6 +13,11 @@
     "type": "git",
     "url": "https://github.com/joliss/broccoli-env"
   },
-  "dependencies": {
+  "dependencies": {},
+  "devDependencies": {
+    "nodeunit": "^0.9.1"
+  },
+  "scripts": {
+    "test": "./node_modules/.bin/nodeunit tests"
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,6 @@
     "nodeunit": "^0.9.1"
   },
   "scripts": {
-    "test": "./node_modules/.bin/nodeunit tests"
+    "test": "nodeunit tests"
   }
 }

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -1,0 +1,137 @@
+function unloadModule() {
+  delete require.cache[require.resolve('../index.js')]
+}
+
+exports['Module Initialization'] = {
+  'Without a BROCCOLI_ENV value': function(test){
+    var defaultEnvList = ['development', 'production']
+    var broccoliEnv = require('../index.js')
+
+    test.deepEqual(
+      defaultEnvList,
+      broccoliEnv.getEnvs(),
+      'Env list should be the default one.'
+    )
+
+    test.equal(
+      defaultEnvList[0],
+      broccoliEnv.getEnv(),
+      'Env list should be the ' + defaultEnvList.join(',') + '.'
+    )
+
+    test.done()
+  },
+  'With a valid BROCCOLI_ENV value': function(test){
+    var defaultEnvList = ['development', 'production']
+    process.env.BROCCOLI_ENV = defaultEnvList[1]
+    var broccoliEnv = require('../index.js')
+
+    test.deepEqual(
+      defaultEnvList,
+      broccoliEnv.getEnvs(),
+      'Env list should be the ' + defaultEnvList.join(',') + '.'
+    )
+
+    test.equal(
+      process.env.BROCCOLI_ENV,
+      broccoliEnv.getEnv(),
+      'Env should be ' + process.env.BROCCOLI_ENV + '.'
+    )
+
+    test.done()
+  },
+  'With an invalid BROCCOLI_ENV value': function(test){
+    var defaultEnvList = ['development', 'production']
+    process.env.BROCCOLI_ENV = 'test'
+    var broccoliEnv = require('../index.js')
+
+    test.deepEqual(
+      defaultEnvList,
+      broccoliEnv.getEnvs(),
+      'Env list should be the ' + defaultEnvList.join(',') + '.'
+    )
+
+    test.equal(
+      defaultEnvList[0],
+      broccoliEnv.getEnv(),
+      'Env should be ' + defaultEnvList[0] + '.'
+    )
+
+    test.done()
+  },
+  tearDown: function(callback) {
+    delete process.env.BROCCOLI_ENV
+    unloadModule()
+    callback()
+  }
+}
+
+exports['Setting a custom environment list'] = {
+  'With a valid env value': function(test){
+    var envList = ['test', 'development', 'production']
+    var broccoliEnv = require('../index.js')
+    var oldEnv = broccoliEnv.getEnv()
+
+    broccoliEnv.setEnvs(envList)
+
+    test.deepEqual(
+      envList,
+      broccoliEnv.getEnvs(),
+      'Env list should be ' + envList.join(',') + '.'
+    )
+
+    test.equal(
+      oldEnv,
+      broccoliEnv.getEnv(),
+      'Env should be ' + oldEnv + '.'
+    )
+
+    test.done()
+  },
+  'With an invalid env value': function(test){
+    var envList = ['test', 'staging', 'production']
+    var broccoliEnv = require('../index.js')
+
+    broccoliEnv.setEnvs(envList)
+
+    test.deepEqual(
+      envList,
+      broccoliEnv.getEnvs(),
+      'Env list should be ' + envList.join(',') + '.'
+    )
+
+    test.equal(
+      envList[0],
+      broccoliEnv.getEnv(),
+      'Env should be ' + envList[0] + '.'
+    )
+
+    test.done()
+  },
+  'With an invalid env list value': function(test){
+    var broccoliEnv = require('../index.js')
+    var invalidEnvLists = ['foo', 1234, undefined, null, {}]
+
+    invalidEnvLists.map(function(param) {
+      test.throws(
+        function() {
+          broccoliEnv.setEnvs(param)
+        },
+        'Should throw an error.'
+      )
+    })
+
+    test.throws(
+      function() {
+        broccoliEnv.setEnvs()
+      },
+      'Should throw an error.'
+    )
+
+    test.done()
+  },
+  tearDown: function(callback) {
+    unloadModule()
+    callback()
+  }
+}


### PR DESCRIPTION
This PR adds a `setEnvs()` method, allowing to set a custom list of environments instead of the current `development` & `production` (which remains the default value).

Inner logic has been updated to handle new behaviors introduced with this method. These behaviors are described in the readme.

A set of tests is also now available.

Note: the error thrown in the event of an invalid env value has been removed due to the defaulting mecanism introduced.
